### PR TITLE
Replace GSAP animations with CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6951,27 +6951,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -6982,15 +6983,17 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6998,39 +7001,42 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
@@ -7040,28 +7046,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -7071,14 +7077,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -7095,7 +7101,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
@@ -7110,14 +7116,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -7127,7 +7133,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -7137,7 +7143,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -7148,53 +7154,58 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7202,7 +7213,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
@@ -7212,23 +7223,24 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "dev": true,
           "optional": true,
@@ -7240,7 +7252,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "dev": true,
           "optional": true,
@@ -7259,7 +7271,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -7270,14 +7282,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
@@ -7288,7 +7300,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -7301,43 +7313,45 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -7348,21 +7362,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -7375,7 +7389,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -7384,7 +7398,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -7400,7 +7414,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
@@ -7410,50 +7424,52 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7462,7 +7478,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -7472,23 +7488,24 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
@@ -7504,14 +7521,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
@@ -7521,15 +7538,17 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7922,11 +7941,6 @@
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
-    },
-    "gsap": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/gsap/-/gsap-2.1.3.tgz",
-      "integrity": "sha512-8RFASCqi2FOCBuv7X4o7M6bLdy+1hbR0azg+MG7zz+EVsI+OmJblYsTk0GEepQd2Jg/ItMPiVTibF7r3EVxjZQ=="
     },
     "gzip-size": {
       "version": "5.0.0",
@@ -11347,7 +11361,7 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
@@ -15293,11 +15307,6 @@
       "requires": {
         "prop-types": "^15.7.2"
       }
-    },
-    "react-gsap-enhancer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/react-gsap-enhancer/-/react-gsap-enhancer-0.3.0.tgz",
-      "integrity": "sha1-ufn9GTFYdXaMQz4JQ8KkHupDt9I="
     },
     "react-icon-base": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -62,10 +62,8 @@
   ],
   "dependencies": {
     "classnames": "^2.2.6",
-    "gsap": "^2.1.3",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
-    "react-gsap-enhancer": "^0.3.0",
     "react-transition-group": "^4.1.1",
     "snyk": "^1.202.0"
   },

--- a/src/components/input/input-status-v1.css
+++ b/src/components/input/input-status-v1.css
@@ -24,45 +24,9 @@
   }
 }
 
-.kui-input__label {
-  .kui-input--variant-one.kui-input--success &,
-  .kui-input--variant-one.kui-input--error & {
-    @mixin themedParent color, input, status;
-  }
-}
-
-.kui-input__field {
-  .kui-input--variant-one.kui-input--success & {
-    @mixin themedParent background-color, input, success;
-  }
-
-  .kui-input--variant-one.kui-input--error & {
-    @mixin themedParent background-color, input, error;
-  }
-
-  .kui-input--variant-one.kui-input--success &,
-  .kui-input--variant-one.kui-input--error & {
-    @mixin themedParent color, input, status;
-  }
-}
-
-.kui-input__line {
-  .kui-input--variant-one.kui-input--success &,
-  .kui-input--variant-one.kui-input--error & {
-    @mixin themedParent background-color, input, status;
-  }
-}
-
 .kui-input__line--filled {
   .kui-input--variant-one.kui-input--success &,
   .kui-input--variant-one.kui-input--error & {
-    @mixin themedParent background-color, input, status;
-  }
-}
-
-.kui-input__description {
-  .kui-input--variant-one.kui-input--success + &,
-  .kui-input--variant-one.kui-input--error + & {
-    @mixin themedParent color, input, textFilled;
+    @mixin themedStart background-color, input, status;
   }
 }

--- a/src/components/input/input.css
+++ b/src/components/input/input.css
@@ -20,9 +20,6 @@ $height-tiny: 1px;
 .kui-input {
   @mixin themed background-color, menu;
 
-  display: flex;
-  flex-direction: column;
-
   /** padding top can be overriden if label is generated (see below) **/
   padding: $padding-top-bottom $padding-left-right;
 
@@ -73,8 +70,7 @@ $height-tiny: 1px;
   @extend %type--regular;
   @extend %type--subhead-2;
 
-  display: flex;
-
+  width: 100%;
   padding: 0;
 
   border: none;
@@ -122,28 +118,23 @@ $height-tiny: 1px;
 }
 
 .kui-input__line {
-  display: flex;
-
   height: $height-tiny;
   margin-top: $margin-top-line;
+  width: 0;
 
   /** by default the background color is transparent; when in active/focus it is visible **/
   background-color: transparent;
 
   pointer-events: none;
-
-  .kui-input__field:active + & {
-    @mixin themedParent background-color, menu, border;
-  }
+  transition: all ease-out 0.4s;
 
   .kui-input__field:focus + &,
   .kui-input__field:active + & {
     @mixin themedParent background-color, menu, border;
-  }
 
-  .kui-input--disabled .kui-input__field:focus + &,
-  .kui-input--disabled .kui-input__field:active + & {
-    background-color: transparent;
+    width: 100%;
+
+    transition: width ease-in 0.4s;
   }
 
   /* stylelint-disable */
@@ -168,10 +159,14 @@ $height-tiny: 1px;
   @extend %type--regular;
   @extend %type--subhead-2;
 
+  display: inline-block;
   height: $height-tiny;
 
   overflow: hidden;
   white-space: pre;
+  vertical-align: top;
+  color: transparent;
+  transition: all ease 0.1s;
 
   .kui-input--focused & {
     @mixin themedStart background-color, input, textFilled;
@@ -189,6 +184,19 @@ $height-tiny: 1px;
 .kui-input__description {
   display: flex;
   padding: 0;
+  visibility: hidden;
+  opacity: 0;
+  transform: scaleY(0.8);
+  transform-origin: top;
+  height: 0;
+  transition: all ease 0.3s;
+
+  &--has-content {
+    visibility: visible;
+    opacity: 1;
+    height: auto;
+    transform: scaleY(1);
+  }
 }
 
 .kui-input__description-content {

--- a/src/components/input/input.css
+++ b/src/components/input/input.css
@@ -10,6 +10,7 @@ $padding-top-bottom: 7px;
 $offset-top-bottom-small: 4px;
 $margin-top-line: 3px;
 $height-tiny: 1px;
+$duration-input-transition: 0.3s;
 
 /** Implementation **/
 
@@ -118,23 +119,27 @@ $height-tiny: 1px;
 }
 
 .kui-input__line {
+  display: flex;
+
   height: $height-tiny;
   margin-top: $margin-top-line;
-  width: 0;
-
-  /** by default the background color is transparent; when in active/focus it is visible **/
-  background-color: transparent;
 
   pointer-events: none;
-  transition: all ease-out 0.4s;
 
-  .kui-input__field:focus + &,
-  .kui-input__field:active + & {
+  &:after {
+    content: '';
+    flex: 0;
+    background-color: transparent;
+    transition: all ease $duration-input-transition;
+  }
+
+
+  .kui-input__field:focus + &:after,
+  .kui-input__field:active + &:after {
     @mixin themedParent background-color, menu, border;
 
-    width: 100%;
-
-    transition: width ease-in 0.4s;
+    flex: 1;
+    transition-timing-function: ease-out;
   }
 
   /* stylelint-disable */
@@ -166,7 +171,7 @@ $height-tiny: 1px;
   white-space: pre;
   vertical-align: top;
   color: transparent;
-  transition: all ease 0.1s;
+  transition: all ease $duration-input-transition;
 
   .kui-input--focused & {
     @mixin themedStart background-color, input, textFilled;
@@ -189,7 +194,7 @@ $height-tiny: 1px;
   transform: scaleY(0.8);
   transform-origin: top;
   height: 0;
-  transition: all ease 0.3s;
+  transition: all ease $duration-input-transition;
 
   &--has-content {
     visibility: visible;

--- a/src/components/input/input.css
+++ b/src/components/input/input.css
@@ -126,16 +126,15 @@ $duration-input-transition: 0.3s;
 
   pointer-events: none;
 
-  &:after {
+  &::after {
     content: '';
     flex: 0;
     background-color: transparent;
     transition: all ease $duration-input-transition;
   }
 
-
-  .kui-input__field:focus + &:after,
-  .kui-input__field:active + &:after {
+  .kui-input__field:focus + &::after,
+  .kui-input__field:active + &::after {
     @mixin themedParent background-color, menu, border;
 
     flex: 1;

--- a/src/components/input/input.jsx
+++ b/src/components/input/input.jsx
@@ -48,10 +48,6 @@ class Input extends React.Component {
    * _handleFocused - changes the focus to enabled state.
    */
   _handleFocused(event) {
-    // if (this.props.status === 'default') {
-    //   this._anim.restart();
-    // }
-
     this.setState({
       focused: true
     });
@@ -234,4 +230,3 @@ Input.propTypes = {
 };
 
 export default Input;
-// export default GSAP()(Input);

--- a/src/components/input/input.jsx
+++ b/src/components/input/input.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import GSAP from 'react-gsap-enhancer';
-import { TimelineLite, Elastic, Power1 } from 'gsap';
 
 import './input.css';
 import './input-status-v1.css';
@@ -31,18 +29,6 @@ class Input extends React.Component {
     this._handleFocused = this._handleFocused.bind(this);
     this._handleBlured = this._handleBlured.bind(this);
     this._handleChanged = this._handleChanged.bind(this);
-
-    this._createAnimation = this._createAnimation.bind(this);
-  }
-
-  /**
-   * React lifecycle method
-   * Adds the animation via GSAP-enhancer to the component.
-   * {@link https://facebook.github.io/react/docs/react-component.html#componentDidMount}
-   * @return {object} JSX for this component
-   */
-  componentDidMount() {
-    this._anim = this.addAnimation(this._createAnimation);
   }
 
   /**
@@ -50,11 +36,7 @@ class Input extends React.Component {
    * {@link https://facebook.github.io/react/docs/react-component.html#componentDidUpdate}
    * @return {object} JSX for this component
    */
-  componentDidUpdate(prevProps, prevState) {
-    if (!this.state.focused && (this.props.status === 'default' || prevProps.status === 'default')) {
-      this._anim.restart();
-    }
-
+  componentDidUpdate(prevProps) {
     if (this.props.value !== null && this.props.value !== prevProps.value) {
       this.setState({
         value: this.props.value
@@ -63,51 +45,12 @@ class Input extends React.Component {
   }
 
   /**
-   * React lifecycle method
-   * Removes the animation created with GSAP-enhancer from the component.
-   * {@link https://facebook.github.io/react/docs/react-component.html#componentWillUnmount}
-   * @return {object} JSX for this component
-   */
-  componentWillUnmount() {
-    this._anim.kill();
-  }
-
-  /**
-   * Animation wrapper made with GSAP.
-   * @return {GSAP}
-   */
-  _createAnimation() {
-    const animationTimeline = new TimelineLite();
-
-    const line = this._line;
-    const lineWidthTimeline = new TimelineLite();
-    lineWidthTimeline
-      .to(line, 0, { width: 0 })
-      .to(line, 1, { width: '100%', ease: Elastic.easeOut.config(0.3, 1) });
-
-    animationTimeline.add(lineWidthTimeline, 0);
-
-    const desc = this._description;
-
-    if (desc) {
-      const descTimeline = new TimelineLite();
-      descTimeline
-        .to(desc, 0, { opacity: 0, ease: Power1.easeIn })
-        .to(desc, 0.7, { opacity: 1, ease: Power1.easeIn });
-
-      animationTimeline.add(descTimeline, 0);
-    }
-
-    return animationTimeline;
-  }
-
-  /**
    * _handleFocused - changes the focus to enabled state.
    */
   _handleFocused(event) {
-    if (this.props.status === 'default') {
-      this._anim.restart();
-    }
+    // if (this.props.status === 'default') {
+    //   this._anim.restart();
+    // }
 
     this.setState({
       focused: true
@@ -151,23 +94,37 @@ class Input extends React.Component {
    * @return {object} JSX for this component
    */
   render() {
-    // status indicating error or success; ignored when it is default
-    const validatedStatus = this.props.status !== 'default' ? this.props.status : false;
+    const {
+      disabled,
+      label,
+      placeholder,
+      status,
+      statusDescription,
+      theme,
+      variant
+    } = this.props;
+    const { focused, value } = this.state;
 
-    const labelWrapper = this.props.label && (
+    // status indicating error or success; ignored when it is default
+    const validatedStatus = status !== 'default' ? status : false;
+    const hasDescription = status !== 'default' && statusDescription;
+
+    const labelWrapper = label && (
       <div className='kui-input__label'>
-        {this.props.label}
+        {label}
       </div>
     );
 
     // description's div has to be always rendered, even if its content is empty
     // to enable the animation to run when the component receives a description; otherwise the animation is ignored
     const description = (
-      <div className='kui-input__description' ref={desc => { this._description = desc; }}>
+      <div className={classnames('kui-input__description', {
+        'kui-input__description--has-content': hasDescription
+      })}>
         {
-          this.props.status !== 'default' && this.props.statusDescription && (
+          statusDescription && (
             <div className='kui-input__description-content'>
-              { this.props.statusDescription }
+              { statusDescription }
             </div>
           )
         }
@@ -179,12 +136,12 @@ class Input extends React.Component {
         <div
           className={classnames(
             'kui-input',
-            `kui-theme--${this.props.theme}`,
+            `kui-theme--${theme}`,
             { [`kui-input--${validatedStatus}`]: !!validatedStatus },
-            { 'kui-input--disabled': this.props.disabled },
-            { 'kui-input--focused': this.state.focused },
-            { 'kui-input--variant-one': this.props.variant === 1 },
-            { 'kui-input--variant-two': this.props.variant === 2 }
+            { 'kui-input--disabled': disabled },
+            { 'kui-input--focused': focused },
+            { 'kui-input--variant-one': variant === 1 },
+            { 'kui-input--variant-two': variant === 2 }
           )}
           onFocus={this._handleFocused}
           onBlur={this._handleBlured}>
@@ -192,15 +149,17 @@ class Input extends React.Component {
           <input
             className='kui-input__field'
             type='text'
-            placeholder={this.props.placeholder || ''}
-            disabled={this.props.disabled}
-            value={this.state.value || ''}
+            placeholder={placeholder || ''}
+            disabled={disabled}
+            value={value || ''}
             onChange={this._handleChanged}
             onFocus={this._handleFocused}
             onBlur={this._handleBlured} />
-          <div className='kui-input__line' ref={line => { this._line = line; }}>
+          <div
+            aria-hidden='true'
+            className='kui-input__line'>
             <div className='kui-input__line--filled'>
-              {this.state.value || ''}
+              {value || ''}
             </div>
           </div>
         </div>
@@ -274,4 +233,5 @@ Input.propTypes = {
   variant: PropTypes.oneOf([0, 1, 2])
 };
 
-export default GSAP()(Input);
+export default Input;
+// export default GSAP()(Input);

--- a/src/components/input/input.test.js
+++ b/src/components/input/input.test.js
@@ -100,17 +100,3 @@ test('It should trigger onChange correctly', () => {
   expect(wrapper.state().value)
     .toBe('new value');
 });
-
-it('Should kill the animation when unmounting', () => {
-  const cb = jest.fn();
-  
-  const wrapper = mount(<Input />);
-  wrapper.instance()._anim = {
-    kill: cb
-  };
-
-  wrapper.unmount();
-
-  expect(cb)
-    .toHaveBeenCalled();
-});

--- a/src/components/modal/Readme.md
+++ b/src/components/modal/Readme.md
@@ -31,8 +31,6 @@ class ModalTrigger extends React.Component {
     return (
       <div>
         <Button theme='light' onClick={this.onTriggered.bind(this)}>Trigger Modal</Button>
-        {
-          this.state.visible &&
           <Modal
             theme='light'
             title='Warning!'
@@ -40,7 +38,6 @@ class ModalTrigger extends React.Component {
             buttonLabel='Confirm Deletion'
             onClose={this.onClose.bind(this)}
             visible={this.state.visible} />
-        }
       </div>
     );
   }
@@ -92,8 +89,6 @@ class ModalTrigger extends React.Component {
     return (
       <div>
         <Button theme='light' onClick={this.onTriggered.bind(this)}>Trigger Modal</Button>
-        {
-          this.state.visible &&
           <Modal
             theme='light'
             title='Custom Modal'
@@ -128,7 +123,6 @@ class ModalTrigger extends React.Component {
               </Button>
             </div>
           </Modal>
-        }
       </div>
     );
   }

--- a/src/components/modal/index.css
+++ b/src/components/modal/index.css
@@ -7,6 +7,7 @@
 $size-spacing: 40px;
 $size-pos: 10px;
 $size-content-maxwidth: 400px;
+$duration-visibility: 0.4s;
 
 /** Implementation **/
 
@@ -18,6 +19,13 @@ $size-content-maxwidth: 400px;
 
   width: 100%;
   height: 100%;
+
+  visibility: hidden;
+  transition: visibility ease $duration-visibility;
+}
+
+.kui-modal--visible {
+  visibility: visible;
 }
 
 .kui-modal__bg {
@@ -27,6 +35,13 @@ $size-content-maxwidth: 400px;
 
   width: 100%;
   height: 100%;
+
+  opacity: 0;
+  transition: opacity ease $duration-visibility;
+}
+
+.kui-modal__bg--visible {
+  opacity: 1;
 }
 
 .kui-modal__content {
@@ -40,6 +55,13 @@ $size-content-maxwidth: 400px;
   max-width: $size-content-maxwidth;
   width: 100%;
 
+  opacity: 0;
+  transform: translate(-50%, -50%) translateY(80px);
+  transition: all ease $duration-visibility;
+}
+
+.kui-modal__content--visible {
+  opacity: 1;
   transform: translate(-50%, -50%);
 }
 

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -32,7 +32,6 @@ class Modal extends React.Component {
    * componentWillMount
    */
   componentDidMount() {
-    // this.entranceAnimation = this.addAnimation(createAnim);
     window.addEventListener('keydown', this._handleKeyDown);
   }
 

--- a/src/components/modal/modal.jsx
+++ b/src/components/modal/modal.jsx
@@ -2,10 +2,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import Button from '../button';
 import Icon from '../icon';
-import GSAP from 'react-gsap-enhancer';
-import { TimelineLite } from 'gsap';
 
 import utils from '../../utils';
 
@@ -14,21 +13,6 @@ import utils from '../../utils';
 import './index.css';
 
 const { handleKeyEvent } = utils;
-
-/**
- * Create animation
- * @type {object} target
- * @return {object} new timeline animation
- */
-const createAnim = ({ target }) => {
-  const bg = target.find({ name: 'bg' });
-  const content = target.find({ name: 'content' });
-
-  return new TimelineLite({ repeat: 0 })
-    .to(bg, 1, { opacity: 1 })
-    .to(content, 1, { opacity: 1, y: '-50%' }, 0)
-    .duration(0.5);
-};
 
 /**
  * Modal component, used for popup dialogs
@@ -41,11 +25,6 @@ class Modal extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {
-      opacity: 0,
-      top: '40%'
-    };
-
     this._handleKeyDown = this._handleKeyDown.bind(this);
   }
 
@@ -53,7 +32,7 @@ class Modal extends React.Component {
    * componentWillMount
    */
   componentDidMount() {
-    this.entranceAnimation = this.addAnimation(createAnim);
+    // this.entranceAnimation = this.addAnimation(createAnim);
     window.addEventListener('keydown', this._handleKeyDown);
   }
 
@@ -84,6 +63,7 @@ class Modal extends React.Component {
       onClose,
       title,
       theme,
+      visible,
       zIndex
     } = this.props;
     let content = null;
@@ -93,14 +73,8 @@ class Modal extends React.Component {
     } else {
       content = (
         <div>
-          <div
-            className='kui-modal__description'>
-            {message}
-          </div>
-          <Button
-            onClick={onClose}
-            theme={theme}
-            size='small'>
+          <div className='kui-modal__description'>{message}</div>
+          <Button onClick={onClose} theme={theme} size='small'>
             {buttonLabel}
           </Button>
         </div>
@@ -118,19 +92,36 @@ class Modal extends React.Component {
     return (
       <div
         aria-haspopup='true'
-        className={`kedro kui-modal kui-theme--${theme}`}
+        className={
+          classnames(
+            `kedro kui-modal kui-theme--${theme}`,
+            {
+              'kui-modal--visible': visible
+            }
+          )
+        }
         onKeyDown={_handleKeyDown}
         role='dialog'
         style={{ zIndex }}>
         <div
           onClick={onClose}
-          name='bg'
-          style={{ opacity: 0 }}
-          className='kui-modal__bg' />
-        <div
-          name='content'
-          style={{ opacity: 0, transform: 'translate(-50%, -40%)' }}
-          className='kui-modal__content'>
+          className={
+            classnames(
+              'kui-modal__bg',
+              {
+                'kui-modal__bg--visible': visible
+              }
+            )
+          }
+        />
+        <div className={
+          classnames(
+            'kui-modal__content',
+            {
+              'kui-modal__content--visible': visible
+            }
+          )
+        }>
           <Icon
             onClick={onClose}
             type='close'
@@ -155,8 +146,9 @@ Modal.defaultProps = {
   buttonLabel: null,
   children: null,
   message: null,
-  zIndex: 9999,
-  theme: 'dark'
+  theme: 'dark',
+  visible: false,
+  zIndex: 9999
 };
 
 Modal.propTypes = {
@@ -185,9 +177,13 @@ Modal.propTypes = {
    */
   theme: PropTypes.oneOf(['light', 'dark']),
   /**
+   * Whether to show the modal
+   */
+  visible: PropTypes.bool,
+  /**
    * zIndex - how far infront of the other content the modal will sit
    */
   zIndex: PropTypes.number
 };
 
-export default GSAP()(Modal);
+export default Modal;


### PR DESCRIPTION
## Description

`react-gsap-enhancer` was throwing errors and warnings in React v16.9 (See https://github.com/azazdeaz/react-gsap-enhancer/issues/47). Furthermore, some of the animations and styles weren't working properly anyway.

I realised that GSAP isn't actually necessary for any of these animations, as you can get away with just using CSS transitions instead.  So I've remove the need for it, and deleted the dependencies.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
