### PR TITLE
Fix CSS bugs

### DIFF
--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -31,6 +31,7 @@ $secondary-underline-offset-hover: 4px;
   background: none;
   box-shadow: none;
   cursor: pointer;
+  font-family: inherit;
   transition:
     background ease $timing-primary,
     outline-color ease $timing-primary,

--- a/src/components/radio-button/radio-button.css
+++ b/src/components/radio-button/radio-button.css
@@ -16,7 +16,7 @@ $size-radio-button-spacing: 14px;
 
   display: inline-block;
 
-  width: $size-dot-dimension;
+  min-width: $size-dot-dimension;
   height: $size-dot-dimension;
 
   margin-right: $size-radio-button-spacing;

--- a/src/components/switch/switch.css
+++ b/src/components/switch/switch.css
@@ -13,6 +13,13 @@ $size-switch-spacing: 14px;
 }
 
 .kui-switch {
+  /**
+    Prevent Chrome 71 focus scroll bug, by containing the
+    visually-hidden mixin in a wrapper to prevent it escaping and somehow
+    messing up the overflow:hidden scroll positioning.
+    */
+  position: relative;
+
   margin-bottom: $size-switch-spacing;
 
   &:active {


### PR DESCRIPTION
## Description
- Fix button font-family, which previously was not inheriting properly
- Prevent radio button circles collapsing when screen gets really narrow
-  Fix focus scroll bug on switch elements
  Prevent Chrome 71 focus scroll bug, by containing the visually-hidden mixin in a wrapper to prevent it escaping and somehow messing up the overflow:hidden scroll positioning.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:
- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
