### PR TITLE
Use What Input? to set obvious keyboard focus states

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6009,10 +6009,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -19574,6 +19577,11 @@
       "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-2.0.0.tgz",
       "integrity": "sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==",
       "dev": true
+    },
+    "what-input": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/what-input/-/what-input-5.2.3.tgz",
+      "integrity": "sha512-ekQJmKNVEPcFIE2YI1L7iXm/m2QTQWe9QqewSCCFZs2ZPo3yOfA8TV8ioBx/JnWZrDUNVGj/YdDJCH5uagMEgg=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2",
     "react-transition-group": "^4.1.1",
-    "snyk": "^1.202.0"
+    "snyk": "^1.202.0",
+    "what-input": "^5.2.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -63,11 +63,11 @@ $secondary-underline-offset-hover: 4px;
   @mixin themedState :disabled, color, text;
 
   &.kui-theme--light:focus {
-    box-shadow: 0 0 0 5px map(themes, light, button, focus);
+    box-shadow: 0 0 0 7px map(themes, light, focus, secondary);
   }
 
   &.kui-theme--dark:focus {
-    box-shadow: 0 0 0 5px map(themes, dark, button, focus);
+    box-shadow: 0 0 0 7px map(themes, dark, focus, secondary);
   }
 
   &:active {
@@ -132,11 +132,17 @@ $secondary-underline-offset-hover: 4px;
       width: 100%;
     }
   }
+
+  [data-whatinput='mouse'] &:focus {
+    box-shadow: none;
+  }
 }
 
 .kui-button__btn--secondary {
-  @mixin themedState :focus::after, background, button, focus;
   @mixin themedState :hover::after, background, button, outline;
+  @mixin themedState :focus, outline-color, focus, secondary;
+
+  outline: 4px solid transparent;
 
   &::after {
     display: block;
@@ -153,8 +159,7 @@ $secondary-underline-offset-hover: 4px;
     background: none;
   }
 
-  &:hover::after,
-  &:focus::after {
+  &:hover::after {
     transform: translateY($secondary-underline-offset-hover);
   }
 
@@ -177,9 +182,12 @@ $secondary-underline-offset-hover: 4px;
     @mixin themedState :after, background, button, outline;
 
     &:active::after,
-    &:focus::after,
     &:hover::after {
       width: 100%;
     }
+  }
+
+  [data-whatinput='mouse'] &:focus {
+    outline: none;
   }
 }

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import 'what-input';
 
 import './button.css';
 

--- a/src/components/checkbox/checkbox.css
+++ b/src/components/checkbox/checkbox.css
@@ -23,7 +23,7 @@ $size-checkmark: 24px;
   margin-right: $size-radio-button-spacing;
 
   border: 2px solid;
-  outline: 3px solid transparent;
+  outline: 4px solid transparent;
   transition: 0.2s all;
 
   .kui-switch__input:checked + .kui-switch-checkbox__label & {
@@ -32,7 +32,11 @@ $size-checkmark: 24px;
   }
 
   .kui-switch__input:focus + .kui-switch-checkbox__label & {
-    @mixin themedParent outline-color, radiobutton, focus;
+    @mixin themedParent outline-color, focus, secondary;
+
+    [data-whatinput='mouse'] & {
+      outline: none;
+    }
   }
 }
 

--- a/src/components/checkbox/checkbox.jsx
+++ b/src/components/checkbox/checkbox.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
+import 'what-input';
 import Switch from '../switch';
 
 // Styles
@@ -14,7 +15,14 @@ import './checkbox.css';
  * its state does not effect other checkboxes, therefore multiple checkboxes can be checked at the same time.
  */
 const Checkbox = ({
-  checked, defaultChecked, disabled, label, name, onChange, theme, value
+  checked,
+  defaultChecked,
+  disabled,
+  label,
+  name,
+  onChange,
+  theme,
+  value
 }) => {
   const id = uniqueId('checkbox');
 
@@ -26,18 +34,19 @@ const Checkbox = ({
       disabled={disabled}
       name={name}
       onChange={onChange}
-      type='checkbox'
+      type="checkbox"
       theme={theme}
       value={value}>
-      <label className='kui-switch-checkbox__label' htmlFor={id}>
-        <div className='kui-switch-checkbox__box'>
-          <svg className='kui-switch-checkbox__inner' viewBox='0 0 24 24'>
-            <g fill='none' fillRule='evenodd'>
-              <path d='M0 0h24v24H0z' />
+      <label className="kui-switch-checkbox__label" htmlFor={id}>
+        <div className="kui-switch-checkbox__box">
+          <svg className="kui-switch-checkbox__inner" viewBox="0 0 24 24">
+            <g fill="none" fillRule="evenodd">
+              <path d="M0 0h24v24H0z" />
               <path
-                className='kui-switch-checkbox__innerfill'
-                d='M2 2h20v20H2V2zm7.923 12.362l-2.538-2.418L6
-                   13.263 9.923 17 18 9.32 16.615 8l-6.692 6.362z' />
+                className="kui-switch-checkbox__innerfill"
+                d="M2 2h20v20H2V2zm7.923 12.362l-2.538-2.418L6
+                   13.263 9.923 17 18 9.32 16.615 8l-6.692 6.362z"
+              />
             </g>
           </svg>
         </div>

--- a/src/components/dropdown/dropdown.css
+++ b/src/components/dropdown/dropdown.css
@@ -60,7 +60,7 @@ $menu-item-padding: 12px;
   border: none;
   border-radius: 0;
   box-shadow: none;
-  outline: 3px solid transparent;
+  outline: 4px solid transparent;
 
   @extend %type--subhead-2;
 
@@ -73,7 +73,11 @@ $menu-item-padding: 12px;
   user-select: none;
 
   &:focus {
-    @mixin themedParent outline-color, menu, hover;
+    @mixin themedParent outline-color, focus, secondary;
+
+    [data-whatinput='mouse'] & {
+      outline: none;
+    }
   }
 
   > .kui-icon {

--- a/src/components/dropdown/dropdown.jsx
+++ b/src/components/dropdown/dropdown.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  flatten, find, flow, isEqual, map
-} from 'lodash/fp';
+import { flatten, find, flow, isEqual, map } from 'lodash/fp';
+import 'what-input';
 
 // Styles
 import './dropdown.css';

--- a/src/components/icon/icon.css
+++ b/src/components/icon/icon.css
@@ -20,6 +20,23 @@
   width: $size-icon-base;
   height: $size-icon-base;
 
+  button& {
+    background: none;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    border-radius: 0;
+    outline: 4px solid transparent;
+
+    &:focus {
+      @mixin themedParent outline-color, focus, secondary;
+    }
+
+    [data-whatinput='mouse'] & {
+      outline: none;
+    }
+  }
+
   /** size variants **/
   &--small {
     width: calc($size-icon-base * 0.5);

--- a/src/components/icon/icon.jsx
+++ b/src/components/icon/icon.jsx
@@ -19,6 +19,8 @@ const Icon = props => {
     color,
     index,
     onClick,
+    onFocus,
+    onBlur,
     size,
     theme,
     title,
@@ -60,10 +62,10 @@ const Icon = props => {
 
   const styleOverrides = typeof color === 'string' ? { style: { fill: color } } : null;
 
-  const Container = onClick ? 'button' : 'span';
+  const Container = (onClick || onFocus || onBlur) ? 'button' : 'span';
 
   return (
-    <Container className={containerClassNames} {...dataProps} onClick={onClick}>
+    <Container className={containerClassNames} {...dataProps} onClick={onClick} onFocus={onFocus} onBlur={onBlur}>
       {SvgIcon && <SvgIcon title={title} className={svgClassNames} {...styleOverrides} />}
       {SvgIcon2 && <SvgIcon2 title={title} className={svgClassNames} {...styleOverrides} />}
     </Container>
@@ -80,9 +82,17 @@ Icon.propTypes = {
    */
   index: PropTypes.oneOf([0, 1]),
   /**
-   * Callback from when an icon is tapped
+   * Callback for when an icon is tapped
    */
   onClick: PropTypes.func,
+  /**
+   * Callback for when an icon is focused
+   */
+  onFocus: PropTypes.func,
+  /**
+   * Callback for when an icon is blurred
+   */
+  onBlur: PropTypes.func,
   /**
    * The size of the whole icon.
    */

--- a/src/components/icon/icon.jsx
+++ b/src/components/icon/icon.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import pickBy from 'lodash/pickBy';
+import 'what-input';
 import IconAssets from './assets';
 
 import './icon.css';
@@ -59,11 +60,13 @@ const Icon = props => {
 
   const styleOverrides = typeof color === 'string' ? { style: { fill: color } } : null;
 
+  const Container = onClick ? 'button' : 'span';
+
   return (
-    <span className={containerClassNames} {...dataProps} onClick={onClick}>
+    <Container className={containerClassNames} {...dataProps} onClick={onClick}>
       {SvgIcon && <SvgIcon title={title} className={svgClassNames} {...styleOverrides} />}
       {SvgIcon2 && <SvgIcon2 title={title} className={svgClassNames} {...styleOverrides} />}
-    </span>
+    </Container>
   );
 };
 

--- a/src/components/input/input.css
+++ b/src/components/input/input.css
@@ -15,7 +15,8 @@ $duration-input-transition: 0.3s;
 /** Implementation **/
 
 .kui-input-wrapper {
-  width: $default-input-width;
+  width: 100%;
+  max-width: $default-input-width;
 }
 
 .kui-input {
@@ -55,7 +56,7 @@ $duration-input-transition: 0.3s;
 
   &.kui-theme--light {
     outline: 4px solid map(themes, light, focus, secondary);
-}
+  }
 
   &.kui-theme--dark {
     outline: 4px solid map(themes, dark, focus, secondary);

--- a/src/components/input/input.css
+++ b/src/components/input/input.css
@@ -27,16 +27,6 @@ $duration-input-transition: 0.3s;
   border: $height-tiny solid rgba(0, 0, 0, 0.12);
   box-sizing: border-box;
 
-  outline: none;
-
-  &:focus {
-    @extend %shadow-light--focus;
-  }
-
-  &:active {
-    @extend %shadow-light--active;
-  }
-
   .kui-theme--dark & {
     @extend %shadow-dark;
 
@@ -62,6 +52,22 @@ $duration-input-transition: 0.3s;
 
 .kui-input--focused {
   @extend %shadow-light--active;
+
+  &.kui-theme--light {
+    outline: 4px solid map(themes, light, focus, secondary);
+}
+
+  &.kui-theme--dark {
+    outline: 4px solid map(themes, dark, focus, secondary);
+  }
+
+  [data-whatintent='keyboard'] & {
+    box-shadow: none;
+  }
+
+  [data-whatintent='mouse'] & {
+    outline: none;
+  }
 }
 
 .kui-input__field {

--- a/src/components/input/input.jsx
+++ b/src/components/input/input.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import 'what-input';
 
 import './input.css';
 import './input-status-v1.css';

--- a/src/components/notification/notification.css
+++ b/src/components/notification/notification.css
@@ -101,7 +101,8 @@ $color-btn-focus: rgba(255, 255, 255, 0.2);
   font-size: 0;
   line-height: 1;
 
-  background: transparent;
+  background: none;
+  outline: 4px solid transparent;
 
   &:hover {
     cursor: pointer;
@@ -112,12 +113,14 @@ $color-btn-focus: rgba(255, 255, 255, 0.2);
   }
 
   &:focus {
-    background: $color-btn-focus;
-
-    outline: none;
+    @mixin themedParent outline-color, focus, secondary;
 
     .kui-icon--close {
       opacity: 1;
     }
+  }
+
+  [data-whatinput='mouse'] & {
+    outline: none;
   }
 }

--- a/src/components/notification/notification.jsx
+++ b/src/components/notification/notification.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import 'what-input';
 import Icon from '../icon';
 
 // Styles

--- a/src/components/radio-button/radio-button.css
+++ b/src/components/radio-button/radio-button.css
@@ -58,11 +58,15 @@ $size-radio-button-spacing: 14px;
 
   .kui-switch__input:focus + .kui-switch-radio__label & {
     .kui-theme--light & {
-      box-shadow: 0 0 0 3px map(themes, light, radiobutton, focus);
+      box-shadow: 0 0 0 4px map(themes, light, focus, secondary);
     }
 
     .kui-theme--dark & {
-      box-shadow: 0 0 0 3px map(themes, dark, radiobutton, focus);
+      box-shadow: 0 0 0 4px map(themes, dark, focus, secondary);
+    }
+
+    [data-whatinput='mouse'] & {
+      box-shadow: none;
     }
   }
 }

--- a/src/components/radio-button/radio-button.jsx
+++ b/src/components/radio-button/radio-button.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
+import 'what-input';
 import Switch from '../switch';
 
 // Styles

--- a/src/components/search-bar/search-bar-renderer.jsx
+++ b/src/components/search-bar/search-bar-renderer.jsx
@@ -25,7 +25,6 @@ const SearchBarRenderer = props => {
     showClearButton,
     value
   } = props;
-  const style = { opacity: showClearButton ? 1 : 0 };
 
   return (
     <form
@@ -45,8 +44,9 @@ const SearchBarRenderer = props => {
         value={value}
         theme={theme}
         type='search' />
-      <div className='kui-searchbar__dynamicicon' style={style}>
-        <Icon onClick={onClear} type='close' size='medium' theme={theme} />
+      <div className={classnames('kui-searchbar__dynamicicon', {
+        'kui-searchbar__dynamicicon--visible': showClearButton })}>
+        <Icon onClick={onClear} type='close' size='medium' theme={theme} onFocus={onFocus} onBlur={onBlur} />
       </div>
       { children }
     </form>

--- a/src/components/search-bar/search-bar.css
+++ b/src/components/search-bar/search-bar.css
@@ -2,6 +2,8 @@
 
 @import '../../styles/includes';
 
+$default-input-width: 320px;
+
 /** Variables **/
 
 $size-icon: 24px;
@@ -13,7 +15,8 @@ $size-pos-base: 10px;
 .kui-searchbar {
   position: relative;
 
-  display: inline-block;
+  width: 100%;
+  max-width: $default-input-width;
 }
 
 .kui-input {

--- a/src/components/search-bar/search-bar.css
+++ b/src/components/search-bar/search-bar.css
@@ -71,6 +71,17 @@ $size-pos-base: 10px;
   }
 }
 
+.kui-searchbar__dynamicicon {
+  visibility: hidden;
+  opacity: 0;
+  transition: all ease 0.1s;
+
+  &--visible {
+    visibility: visible;
+    opacity: 1;
+  }
+}
+
 .kui-icon--close {
   .kui-searchbar & {
     right: $size-pos-base;

--- a/src/components/search-bar/search-bar.jsx
+++ b/src/components/search-bar/search-bar.jsx
@@ -101,7 +101,7 @@ class SearchBar extends React.Component {
   /**
    * onClose - clear the text in the input
    */
-  _handleCleared() {
+  _handleCleared(event) {
     this.setState({
       value: '',
       showClearButton: false
@@ -116,6 +116,8 @@ class SearchBar extends React.Component {
     if (typeof this.props.onChange === 'function') {
       this.props.onChange('');
     }
+
+    event.preventDefault();
   }
 
   /**

--- a/src/components/search-results/search-results.css
+++ b/src/components/search-results/search-results.css
@@ -42,6 +42,7 @@ $results-row-padding: 8px 20px 12px 44px;
   height: 100%;
   overflow: auto;
 
+  margin: 0;
   padding: $results-list-vertical-padding 0;
   transition: all ease $results-list-vertical-transition;
   box-sizing: border-box;

--- a/src/components/search/search.css
+++ b/src/components/search/search.css
@@ -1,3 +1,0 @@
-.kui-search {
-  display: inline-block;
-}

--- a/src/components/search/search.jsx
+++ b/src/components/search/search.jsx
@@ -6,10 +6,6 @@ import SearchBar from '../search-bar';
 import SearchResults from '../search-results';
 import utils from '../../utils';
 
-// Styles
-
-import './search.css';
-
 const { escapeRegExp, handleKeyEvent } = utils;
 
 /**

--- a/src/components/slider/slider-common.css
+++ b/src/components/slider/slider-common.css
@@ -60,11 +60,15 @@ $hidden-elements-height: 1px;
 
 @define-mixin thumb-focus-style {
   .kui-theme--light & {
-    box-shadow: 0 0 0 3px map(themes, light, slider, focus);
+    box-shadow: 0 0 0 4px map(themes, light, focus, secondary);
   }
 
   .kui-theme--dark & {
-    box-shadow: 0 0 0 3px map(themes, dark, slider, focus);
+    box-shadow: 0 0 0 4px map(themes, dark, focus, secondary);
+  }
+
+  [data-whatinput='mouse'] & {
+    box-shadow: none;
   }
 }
 

--- a/src/components/slider/slider.jsx
+++ b/src/components/slider/slider.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { uniqueId } from 'lodash/fp';
+import 'what-input';
 
 import SliderRenderer from './slider-renderer';
 import RangedSliderRenderer from './ranged-slider-renderer';

--- a/src/components/tabs/tabs.css
+++ b/src/components/tabs/tabs.css
@@ -81,7 +81,7 @@ $duration-underline-hovered: 0.5s;
   box-shadow: none;
   text-decoration: none;
   cursor: pointer;
-  outline: none;
+  outline: 4px solid transparent;
 
   &:hover {
     text-decoration: none;
@@ -89,10 +89,15 @@ $duration-underline-hovered: 0.5s;
 
   &:focus {
     @mixin themedParent color, text;
+    @mixin themedParent outline-color, focus, secondary;
   }
 
   &:active {
     @mixin themedParent background-color, tabs, active;
+  }
+
+  [data-whatintent='mouse'] & {
+    outline: none;
   }
 }
 

--- a/src/components/tabs/tabs.jsx
+++ b/src/components/tabs/tabs.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import 'what-input';
 import TabsRenderer from './tabs-renderer';
 
 import './tabs.css';

--- a/src/components/toggle/toggle.css
+++ b/src/components/toggle/toggle.css
@@ -7,6 +7,7 @@
 $size-toggle-margin: 12px;
 $size-toggle-outline: 7px;
 $size-toggle-padding: 4px;
+$size-toggle-outline-padding: 6px;
 $size-toggle-text-margin: 8px;
 $size-toggle-margin-bottom: -3px;
 $size-toggle-margin-small: 10px;
@@ -86,10 +87,21 @@ $duration-switch-hover: 0.1s;
     }
   }
 
-  .kui-switch__input:active + &,
-  .kui-switch__input:focus + & {
+  .kui-switch__input:active + & {
     @mixin themedParent outline-color, toggle, focus;
     @mixin themedParent background-color, toggle, focus;
+  }
+
+  .kui-switch__input:focus + & {
+    @mixin themedParent outline-color, focus, secondary;
+
+    outline-width: 4px;
+    padding: $size-toggle-outline-padding;
+    margin: -$size-toggle-outline-padding -$size-toggle-outline-padding calc($size-toggle-text-margin - $size-toggle-outline-padding);
+
+    [data-whatinput='mouse'] & {
+      outline: none;
+    }
   }
 }
 

--- a/src/components/toggle/toggle.jsx
+++ b/src/components/toggle/toggle.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
 import assert from 'assert';
+import 'what-input';
 import utils from '../../utils';
 import ToggleRenderer from './toggle-renderer';
 


### PR DESCRIPTION
## Description

- Use [What Input?](https://github.com/ten1seven/what-input/) to add a consistent and obvious tabbed focus state for keyboard users only, while preventing mouse users from needing to see the massive colourful outline. ([demo](https://twitter.com/RichardWestenra/status/1164909513125900288))
- Add button element for Icon when onClick is handled, to improve keyboard-accessibility for icon buttons
- Fix Search height overflow bug (when the underline element is populated) by setting Search element wrappers to `display: block` instead of `inline-block`.
- Improve Input width-handling by setting Search/Input element wrappers to `width: 100%; max-width: 320px;` so that they're responsive by default.
- Handle search-bar close icon focus/blur, so that the SearchBar icons still have focus state applied when the close icon is focused.
- Fix margin bug in search-results (This bug was probably introduced when the CSS reset was removed from the project)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:
- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
