### PR TITLE
Fix z-index bug on styleguide preview panel

### DIFF
--- a/styleguide/components/Preview.js
+++ b/styleguide/components/Preview.js
@@ -21,7 +21,9 @@ const styles = ({ fontFamily }) => ({
   previewBg: {
     borderWidth: 1,
     borderStyle: 'solid',
-    padding: 40,
+    padding: 40
+  },
+  themeButtonWrapper: {
     position: 'relative'
   },
   themeButton: {
@@ -58,21 +60,25 @@ export class Preview extends React.Component {
     const themedCode = code.replace(/theme='light'/g, `theme='${theme}'`);
 
     return (
-      <div
-        className={classes.previewBg}
-        style={{
-          background: BACKGROUND_COLOR[theme],
-          borderColor: BORDER_COLOR[theme]
-        }}>
-        <button
-          className={classes.themeButton}
-          onClick={this.toggleTheme.bind(this)}
-          style={{ color: COLOR[theme] }}>
-          { theme.toUpperCase() }
-        </button>
-        <DefaultPreview {...this.props} code={themedCode}>
-          {children}
-        </DefaultPreview>
+      <div>
+        <div className={classes.themeButtonWrapper}>
+          <button
+            className={classes.themeButton}
+            onClick={this.toggleTheme.bind(this)}
+            style={{ color: COLOR[theme] }}>
+            { theme.toUpperCase() }
+          </button>
+        </div>
+        <div
+          className={classes.previewBg}
+          style={{
+            background: BACKGROUND_COLOR[theme],
+            borderColor: BORDER_COLOR[theme]
+          }}>
+          <DefaultPreview {...this.props} code={themedCode}>
+            {children}
+          </DefaultPreview>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
## Description

The Preview panel had `position: relative` applied, which applied z-index stacking context, which messed with some of the default styles in dropdowns, search results, etc.
![image](https://user-images.githubusercontent.com/1155816/64794257-25e1fa00-d574-11e9-8692-cb60d4638548.png)

Rather than fix the styles of the components to fix the styleguide, I'd rather just remove the need to override the positioning, by only applying the position relative to the button's container. This way, it gets positioned where we want, but it doesn't affect any other elements.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:
- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
