### PR TITLE
Fix font-family on dropdown button

### DIFF
--- a/src/components/dropdown/dropdown.css
+++ b/src/components/dropdown/dropdown.css
@@ -61,6 +61,7 @@ $menu-item-padding: 12px;
   border-radius: 0;
   box-shadow: none;
   outline: 4px solid transparent;
+  font-family: inherit;
 
   @extend %type--subhead-2;
 


### PR DESCRIPTION
The button's system font was overriding its parent font-family

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
