### PR TITLE
Fix light theme dropdown menu-option active colour

### DIFF
--- a/src/styles/themes/palette.yml
+++ b/src/styles/themes/palette.yml
@@ -29,8 +29,8 @@ themes:
     menu:
       default: rgb(255, 255, 255)
       hover: rgb(230, 232, 235)
-      active: rgb(29, 48, 59)
-      activeColor: rgb(255, 255, 255)
+      active: rgb(200, 200, 200)
+      activeColor: rgb(0, 0, 0)
       selected: rgba(0, 0, 0, 0.06)
       border: rgba(0, 0, 0, 0.12)
       wrapper: rgba(0, 0, 0, 0.12)


### PR DESCRIPTION
Currently, the light theme colours are the same as the dark

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
