### PR TITLE
Target specific properties in CSS transitions, instead of 'all'

### DIFF
--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -122,7 +122,7 @@ $secondary-underline-offset-hover: 4px;
 
       width: 0;
       height: 100%;
-      transition: all ease $timing-primary;
+      transition: width ease $timing-primary;
     }
 
     @mixin themedState :after, background, button, outline;
@@ -154,7 +154,7 @@ $secondary-underline-offset-hover: 4px;
     /* Offset the underline height so it doesn't affect text vertical alignment */
     margin-bottom: -$secondary-underline-height;
     transform: translateY($secondary-underline-offset);
-    transition: all ease 0.1s;
+    transition: transform ease 0.1s, background ease 0.1s;
 
     background: none;
   }
@@ -175,7 +175,7 @@ $secondary-underline-offset-hover: 4px;
   &.kui-button__btn--wipe {
     &::after {
       width: 0;
-      transition: all ease 0.2s;
+      transition: width ease 0.2s;
       transform: translateY(4px);
     }
 

--- a/src/components/checkbox/checkbox.css
+++ b/src/components/checkbox/checkbox.css
@@ -7,6 +7,7 @@
 $size-dot-dimension: 20px;
 $size-radio-button-spacing: 14px;
 $size-checkmark: 24px;
+$timing-primary: 0.2s;
 
 /** Implementation **/
 
@@ -24,7 +25,7 @@ $size-checkmark: 24px;
 
   border: 2px solid;
   outline: 4px solid transparent;
-  transition: 0.2s all;
+  transition: oapcity $timing-primary, border-color $timing-primary;
 
   .kui-switch__input:checked + .kui-switch-checkbox__label & {
     border-color: transparent;
@@ -46,24 +47,21 @@ $size-checkmark: 24px;
   top: 50%;
   left: 50%;
 
-  width: 1px;
-  height: 1px;
+  width: $size-checkmark;
+  height: $size-checkmark;
 
-  transition: 0.2s all;
-  transform: translate(-50%, -50%);
+  transition: transform $timing-primary, opacity $timing-primary;
+  transform: translate(-50%, -50%) scale(0);
+  opacity: 0;
 
   .kui-switch__input:checked + .kui-switch-checkbox__label & {
-    width: $size-checkmark;
-    height: $size-checkmark;
-
-    transition: 0.2s all;
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
   }
 }
 
 .kui-switch-checkbox__innerfill {
-  .kui-switch__input:checked + .kui-switch-checkbox__label & {
-    @mixin themedParent fill, radiobutton;
-  }
+  @mixin themedParent fill, radiobutton;
 }
 
 .kui-switch-checkbox__label {

--- a/src/components/input/input.css
+++ b/src/components/input/input.css
@@ -143,7 +143,7 @@ $duration-input-transition: 0.3s;
     white-space: pre;
     background-color: transparent;
     color: transparent;
-    transition: all ease $duration-input-transition;
+    transition: background-color $duration-input-transition;
 
     .kui-input--focused & {
       @mixin themedStart background-color, input, textFilled;
@@ -162,7 +162,9 @@ $duration-input-transition: 0.3s;
     content: '';
     flex: 0;
     background-color: transparent;
-    transition: all ease $duration-input-transition;
+    transition:
+      background-color $duration-input-transition,
+      flex $duration-input-transition;
   }
 
   .kui-input__field:focus + &::after,
@@ -196,13 +198,21 @@ $duration-input-transition: 0.3s;
   transform: scaleY(0.8);
   transform-origin: top;
   height: 0;
-  transition: all ease $duration-input-transition;
+  transition:
+    visibility $duration-input-transition,
+    opacity $duration-input-transition,
+    height $duration-input-transition,
+    transform $duration-input-transition;
 
   &--has-content {
     visibility: visible;
     opacity: 1;
     height: auto;
     transform: scaleY(1);
+    transition:
+      opacity $duration-input-transition,
+      height $duration-input-transition,
+      transform $duration-input-transition;
   }
 }
 

--- a/src/components/modal/index.css
+++ b/src/components/modal/index.css
@@ -57,7 +57,9 @@ $duration-visibility: 0.4s;
 
   opacity: 0;
   transform: translate(-50%, -50%) translateY(80px);
-  transition: all ease $duration-visibility;
+  transition:
+    opacity $duration-visibility,
+    transform $duration-visibility;
 }
 
 .kui-modal__content--visible {

--- a/src/components/notification/notification-list.css
+++ b/src/components/notification/notification-list.css
@@ -26,7 +26,7 @@ $size-spacing: 20px;
 .kui-notification-animation-enter.kui-notification-animation-enter-active {
   opacity: 1;
 
-  transition: all 500ms;
+  transition: opacity 500ms;
 }
 
 .kui-notification-animation-exit {
@@ -36,5 +36,5 @@ $size-spacing: 20px;
 .kui-notification-animation-exit.kui-notification-animation-exit-active {
   opacity: 0;
 
-  transition: all 300ms ease-in;
+  transition: opacity 300ms ease-in;
 }

--- a/src/components/radio-button/radio-button.css
+++ b/src/components/radio-button/radio-button.css
@@ -5,6 +5,7 @@
 /** Variables **/
 
 $size-dot-dimension: 20px;
+$size-dot-inner-dimension: 12px;
 $size-radio-button-spacing: 14px;
 
 /** Implementation **/
@@ -23,7 +24,6 @@ $size-radio-button-spacing: 14px;
 
   border: 2px solid;
   border-radius: 50%;
-  transition: all 0.3s;
 
   &::before {
     @mixin themedParent background, radiobutton, default;
@@ -35,24 +35,25 @@ $size-radio-button-spacing: 14px;
 
     content: ' ';
 
-    width: 0%;
-    height: 0%;
+    width: $size-dot-inner-dimension;
+    height: $size-dot-inner-dimension;
 
     border-radius: 50%;
 
     opacity: 0;
 
-    transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%) scale(0);
 
-    transition: all 0.3s;
+    transition:
+      opacity 0.3s,
+      transform 0.3s;
   }
 
   .kui-switch__input:checked + .kui-switch-radio__label & {
     &::before {
-      width: 80%;
-      height: 80%;
-
       opacity: 1;
+
+      transform: translate(-50%, -50%) scale(1);
     }
   }
 

--- a/src/components/search-bar/search-bar.css
+++ b/src/components/search-bar/search-bar.css
@@ -74,11 +74,12 @@ $size-pos-base: 10px;
 .kui-searchbar__dynamicicon {
   visibility: hidden;
   opacity: 0;
-  transition: all ease 0.1s;
+  transition: opacity 0.1s, visibility 0.1s;
 
   &--visible {
     visibility: visible;
     opacity: 1;
+    transition: opacity 0.1s;
   }
 }
 

--- a/src/components/search-results/search-results.css
+++ b/src/components/search-results/search-results.css
@@ -23,7 +23,9 @@ $results-row-padding: 8px 20px 12px 44px;
   overflow: hidden;
 
   width: $search-input-width;
-  transition: all ease $results-list-vertical-transition;
+  transition:
+    height $results-list-vertical-transition,
+    max-height $results-list-vertical-transition;
   box-sizing: border-box;
 
   @mixin themed background, menu, default;
@@ -44,7 +46,6 @@ $results-row-padding: 8px 20px 12px 44px;
 
   margin: 0;
   padding: $results-list-vertical-padding 0;
-  transition: all ease $results-list-vertical-transition;
   box-sizing: border-box;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12) inset;
 }

--- a/src/components/toggle/toggle.css
+++ b/src/components/toggle/toggle.css
@@ -77,7 +77,7 @@ $duration-switch-hover: 0.1s;
   display: flex;
   margin: 0 0 $size-toggle-text-margin;
   cursor: pointer;
-  transition: $duration-switch-hover;
+  transition: color $duration-switch-hover;
   outline: $size-toggle-outline solid transparent;
   transform: translateY($size-toggle-y-offset);
 
@@ -139,7 +139,7 @@ $duration-switch-hover: 0.1s;
 }
 
 .kui-toggle__separator {
-  transition: $duration-separator-switch;
+  transition: transform $duration-separator-switch;
 
   margin: $size-separator-margin;
 


### PR DESCRIPTION
## Description

Avoid the use of `transition: all`, in order to fix animation issues in Safari, which led to weird delays when components were children of elements toggled with the 'visibility' property.

This PR also fixes some slightly buggy exit animations on the checkbox component, and also fixes some buggy sub-pixel rendering issues on the radio button component:
![image](https://user-images.githubusercontent.com/1155816/67694292-0293d280-f99b-11e9-8685-5e289537484f.png)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
