### PR TITLE
Remove Source Code Pro and Titillium Web 300 webfonts

### DIFF
--- a/src/styles/typography/extends.css
+++ b/src/styles/typography/extends.css
@@ -4,10 +4,6 @@
 }
 
 /* Weights */
-%type--light {
-  font-weight: 300;
-}
-
 %type--regular {
   font-weight: 400;
 }

--- a/src/styles/typography/styles.css
+++ b/src/styles/typography/styles.css
@@ -1,5 +1,5 @@
 @import './extends';
-@import url(https://fonts.googleapis.com/css?family=Titillium+Web:300,400,600);
+@import url(https://fonts.googleapis.com/css?family=Titillium+Web:400,600);
 
 .kedro {
   @extend %base;

--- a/src/styles/typography/styles.css
+++ b/src/styles/typography/styles.css
@@ -1,6 +1,5 @@
 @import './extends';
 @import url(https://fonts.googleapis.com/css?family=Titillium+Web:300,400,600);
-@import url('https://fonts.googleapis.com/css?family=Source+Code+Pro');
 
 .kedro {
   @extend %base;


### PR DESCRIPTION
## Description

These webfonts/weights don't appear to be used anywhere.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
