### PR TITLE
Add margin:2px to Button to offset the CSS outline

### DIFF
--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -23,6 +23,7 @@ $secondary-underline-offset-hover: 4px;
   @mixin themed color, text;
 
   display: inline-block;
+  margin: 2px;
   padding: 0.7em 0.8em 0.8em;
   line-height: 1em;
   border: none;


### PR DESCRIPTION
## Description

Fix inconsistency between Safari/Chrome, and offset the 2px outline when applying margin to the container.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
