### PR TITLE
Add optional focused prop to input and search-bar

### DIFF
--- a/src/components/input/input.jsx
+++ b/src/components/input/input.jsx
@@ -21,9 +21,10 @@ class Input extends React.Component {
     super(props);
 
     this.displayName = 'Input';
+    this.textInput = React.createRef();
 
     this.state = {
-      focused: false,
+      focused: null,
       value: this.props.value
     };
 
@@ -42,6 +43,12 @@ class Input extends React.Component {
       this.setState({
         value: this.props.value
       });
+    }
+
+    if (this.props.focused === true) {
+      this.textInput.current.focus();
+    } else if (this.props.focused === false) {
+      this.textInput.current.blur();
     }
   }
 
@@ -145,6 +152,7 @@ class Input extends React.Component {
           {labelWrapper}
           <input
             className='kui-input__field'
+            ref={this.textInput}
             type='text'
             placeholder={placeholder || ''}
             disabled={disabled}
@@ -165,6 +173,7 @@ class Input extends React.Component {
 
 Input.defaultProps = {
   disabled: false,
+  focused: null,
   label: null,
   onBlur: null,
   onFocus: null,

--- a/src/components/input/input.jsx
+++ b/src/components/input/input.jsx
@@ -35,6 +35,15 @@ class Input extends React.Component {
 
   /**
    * React lifecycle method
+   * {@link https://facebook.github.io/react/docs/react-component.html#componentDidMount}
+   * @return {object} JSX for this component
+   */
+  componentDidMount() {
+    this.updateInputFocus();
+  }
+
+  /**
+   * React lifecycle method
    * {@link https://facebook.github.io/react/docs/react-component.html#componentDidUpdate}
    * @return {object} JSX for this component
    */
@@ -45,10 +54,25 @@ class Input extends React.Component {
       });
     }
 
-    if (this.props.focused === true) {
+    this.updateInputFocus();
+  }
+
+  /**
+   * _updateInputFocus - calls native focus or blur on the input element if prop set.
+   */
+  updateInputFocus() {
+    if (this.props.focused === true && this.state.focused !== true) {
       this.textInput.current.focus();
-    } else if (this.props.focused === false) {
+
+      if (typeof jest !== 'undefined') {
+        this._handleFocused({ target: {} });
+      }
+    } else if (this.props.focused === false && this.state.focused !== false) {
       this.textInput.current.blur();
+
+      if (typeof jest !== 'undefined') {
+        this._handleBlured({ target: {} });
+      }
     }
   }
 
@@ -191,6 +215,10 @@ Input.propTypes = {
    * Whether the input should be editable or not.
    */
   disabled: PropTypes.bool,
+  /**
+   * Whether the input should be focused or blured (if set).
+   */
+  focused: PropTypes.bool,
   /**
    * Label indicating what should be written in the input.
    */

--- a/src/components/input/input.test.js
+++ b/src/components/input/input.test.js
@@ -100,3 +100,45 @@ test('It should trigger onChange correctly', () => {
   expect(wrapper.state().value)
     .toBe('new value');
 });
+
+test('It should trigger onFocus when focused prop set on mount', () => {
+  const cb = jest.fn();
+
+  const wrapper = mount(<Input focused={true} onFocus={cb} />);
+
+  expect(cb)
+    .toHaveBeenCalled();
+
+  expect(wrapper.find('.kui-input--focused').length).toBe(1);
+});
+
+test('It should trigger onFocus and onBlur when focused prop changes', () => {
+  const onFocus = jest.fn();
+  const onBlur = jest.fn();
+
+  const wrapper = mount(<Input focused={null} onFocus={onFocus} onBlur={onBlur} />);
+
+  expect(onFocus)
+    .not.toHaveBeenCalled();
+
+  expect(onBlur)
+    .not.toHaveBeenCalled();
+
+  expect(wrapper.find('.kui-input--focused').length).toBe(0);
+
+  wrapper.setProps({ focused: true });
+  wrapper.update();
+
+  expect(onFocus)
+    .toHaveBeenCalled();
+
+  expect(wrapper.find('.kui-input--focused').length).toBe(1);
+
+  wrapper.setProps({ focused: false });
+  wrapper.update();
+
+  expect(onBlur)
+    .toHaveBeenCalled();
+
+  expect(wrapper.find('.kui-input--focused').length).toBe(0);
+});

--- a/src/components/search-bar/Readme.md
+++ b/src/components/search-bar/Readme.md
@@ -57,7 +57,7 @@ class ChangeParent extends React.Component {
 
     return (
       <div>
-        <SearchBar value={this.state.currentText} onChange={this.onChange} theme='light' iconType='refresh'/>
+        <SearchBar value={this.state.currentText} onChange={this.onChange} theme='light' />
         <div style={style}>Text From SearchBar: {this.state.currentText}</div>
         <Button size='small' theme='light' onClick={()=> { this.setState({currentText: 'something'}); }}>Set External Value</Button>
       </div>
@@ -66,4 +66,67 @@ class ChangeParent extends React.Component {
 }
 
 <ChangeParent />
+```
+
+```
+import SearchBar from 'components/search-bar';
+import Button from 'components/button';
+
+class FocusParent extends React.Component {
+  constructor(props) {
+    super(props);
+    
+    this.setFocused = this.setFocused.bind(this);
+    this.focusTimeout = null;
+
+    this.state = {
+      isFocused: false
+    };
+  }
+
+  setFocused(isFocused) {
+    this.setState({ isFocused });
+    clearTimeout(this.focusTimeout);
+
+    if (isFocused) {
+      this.focusTimeout = setTimeout(() => {
+        this.setState({ isFocused: false });
+      }, 5000);
+    }
+  }
+
+  render() {
+    const style = {
+      color: 'grey',
+      margin: '20px 0'
+    };
+
+    const isFocused = this.state.isFocused;
+    const text = isFocused ? 'Blur in 5 seconds...' : 'Focus';
+
+    return (
+      <div>
+        <SearchBar 
+          theme='light' 
+          focused={this.state.isFocused}
+          onFocus={() => this.setFocused(true)} 
+          onBlur={() => this.setFocused(false)}
+        />
+        <Button 
+          size='small' 
+          theme='light'
+          disabled={this.state.isFocused}
+          onClick={() => this.setFocused(true)}
+        >{text}</Button>
+        <Button 
+          size='small' 
+          theme='light' 
+          onClick={() => this.setFocused(false)}
+        >Blur</Button>
+      </div>
+    );
+  }
+}
+
+<FocusParent />
 ```

--- a/src/components/search-bar/search-bar-renderer.jsx
+++ b/src/components/search-bar/search-bar-renderer.jsx
@@ -38,6 +38,7 @@ const SearchBarRenderer = props => {
       <Input
         id='kui-searchbar'
         placeholder={placeholder}
+        focused={isFocused}
         onChange={onChange}
         onFocus={onFocus}
         onBlur={onBlur}
@@ -55,7 +56,8 @@ const SearchBarRenderer = props => {
 
 SearchBarRenderer.defaultProps = {
   children: null,
-  onSubmit: null
+  onSubmit: null,
+  isFocused: null
 };
 
 SearchBarRenderer.propTypes = {
@@ -70,7 +72,7 @@ SearchBarRenderer.propTypes = {
   /**
    * Indicating whether the search bar is focused or blurred
    */
-  isFocused: PropTypes.bool.isRequired,
+  isFocused: PropTypes.bool,
   /**
    * Place holder text for search input
    */

--- a/src/components/search-bar/search-bar.jsx
+++ b/src/components/search-bar/search-bar.jsx
@@ -24,7 +24,7 @@ class SearchBar extends React.Component {
 
     this.state = {
       value: this.props.value,
-      isFocused: null,
+      isFocused: this.props.focused,
       showClearButton: this.props.value !== ''
     };
 
@@ -175,7 +175,8 @@ SearchBar.defaultProps = {
   onFocus: null,
   onSubmit: null,
   theme: 'dark',
-  value: ''
+  value: '',
+  focused: null
 };
 
 SearchBar.propTypes = {

--- a/src/components/search-bar/search-bar.jsx
+++ b/src/components/search-bar/search-bar.jsx
@@ -24,7 +24,7 @@ class SearchBar extends React.Component {
 
     this.state = {
       value: this.props.value,
-      isFocused: false,
+      isFocused: null,
       showClearButton: this.props.value !== ''
     };
 
@@ -46,6 +46,12 @@ class SearchBar extends React.Component {
       this.setState({
         value: this.props.value,
         showClearButton: this.props.value !== ''
+      });
+    }
+
+    if (this.props.focused !== prevProps.focused) {
+      this.setState({
+        isFocused: this.props.focused
       });
     }
   }
@@ -212,7 +218,11 @@ SearchBar.propTypes = {
   /**
    * Value of the inner input bar
    */
-  value: PropTypes.string
+  value: PropTypes.string,
+  /**
+   * Sets the focus
+   */
+  focused: PropTypes.bool
 };
 
 export default SearchBar;

--- a/src/components/search-bar/search-bar.test.js
+++ b/src/components/search-bar/search-bar.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, configure } from 'enzyme';
+import { shallow, mount, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import SearchBar from './search-bar';
 
@@ -23,4 +23,39 @@ test('SearchBar should render correctly', () => {
     .toBe('function');
   expect(typeof wrapper.props().onClear)
     .toBe('function');
+});
+
+
+test('It should trigger onFocus when focused prop set on mount', () => {
+  const cb = jest.fn();
+
+  const wrapper = mount(<SearchBar focused={true} onFocus={cb} />);
+
+  expect(cb)
+    .toHaveBeenCalled();
+});
+
+test('It should trigger onFocus and onBlur when focused prop changes', () => {
+  const onFocus = jest.fn();
+  const onBlur = jest.fn();
+
+  const wrapper = mount(<SearchBar focused={null} onFocus={onFocus} onBlur={onBlur} />);
+
+  expect(onFocus)
+    .not.toHaveBeenCalled();
+
+  expect(onBlur)
+    .not.toHaveBeenCalled();
+
+  wrapper.setProps({ focused: true });
+  wrapper.update();
+
+  expect(onFocus)
+    .toHaveBeenCalled();
+
+  wrapper.setProps({ focused: false });
+  wrapper.update();
+
+  expect(onBlur)
+    .toHaveBeenCalled();
 });


### PR DESCRIPTION
## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Motivation and Context
- Adds an optional `focused` prop to `input` and `search-bar` components to trigger focus (or blur) programatically.
- This is useful for a user implementing e.g. a custom keyboard shortcut.

## How has this been tested?
- Added an example that shows setting focused on and off (blur) both with user interaction (buttons) and programatically (a timer).
- Added unit tests for the new prop on mount and change.
- Other related components were tested for regression. 
- Tested in Chrome and Firefox.

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added tests to cover my changes
- [ ] Assigned myself to the PR
- [ ] Added `Type` label to the PR
