### PR TITLE
Add transition-out for closing tooltip

### DIFF
--- a/src/components/dropdown/dropdown.css
+++ b/src/components/dropdown/dropdown.css
@@ -106,7 +106,7 @@ $menu-item-padding: 12px;
 
   position: absolute;
 
-  display: none;
+  visibility: hidden;
   width: 100%;
   max-height: $menu-max-height;
   overflow: auto;
@@ -114,10 +114,15 @@ $menu-item-padding: 12px;
 
   border-style: solid;
   border-width: 1px 0 0;
-  animation: dropdownEntrance 0.3s;
+  transition: opacity ease 0.2s, transform ease 0.2s, visibility ease 0.2s;
+  transform: translateY(-10px);
+  opacity: 0;
 
   .kui-dropdown--open & {
-    display: block;
+    visibility: visible;
+    transition: opacity ease 0.3s, transform ease 0.3s, visibility ease 0.3s;
+    opacity: 1;
+    transform: translateY(0);
   }
 
   > section {
@@ -160,17 +165,5 @@ $menu-item-padding: 12px;
       @extend %type--body-1;
       @extend %type--semibold;
     }
-  }
-}
-
-@keyframes dropdownEntrance {
-  0% {
-    opacity: 0.5;
-    transform: translateY(-10px);
-  }
-
-  100% {
-    opacity: 1;
-    transform: translateY(0);
   }
 }


### PR DESCRIPTION
## Description

At present, when you hide the dropdown, it disappears instantly. This doesn't look quite right as it has an opening animation. I've changed it so that it maintains the 0.3s transition on opening, and has a 0.2s transition out on close. This is because it is typically a good idea to have a shorter transition out when you hide elements on a screen, than when showing them.

## Development notes

By changing from `display: none` to `visibility: hidden`, we're able to transition the property and avoid the need for a css animation or complex jQuery-style javascript fadeout animations. This keeps things simple.

Toggling `visibility` does have a non-negligible effect on animation performance in principle (as it's not GPU-accelerated), but no more than toggling `display`, and either way, in this case it's not noticeable at all. Note that the GPU-accelerated alternative (just use `opacity` + `pointer-events`) would not be good for accessibility as it would still allow the dropdown options to be keyboard/screenreader-accessible even when hidden)

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
