### PR TITLE
Add disabled state to Dropdown component

### DIFF
--- a/src/components/dropdown/Readme.md
+++ b/src/components/dropdown/Readme.md
@@ -107,6 +107,13 @@ class Wrap extends React.Component {
 ```
 
 
+A disabled dropdown
+```
+import Dropdown from 'components/dropdown';
+
+<Dropdown disabled={true} theme='light' />
+```
+
 Using sections and headings to group menu options.
 ```
 import Dropdown from 'components/dropdown';

--- a/src/components/dropdown/dropdown-renderer.jsx
+++ b/src/components/dropdown/dropdown-renderer.jsx
@@ -15,6 +15,7 @@ const { handleKeyEvent } = utils;
 const DropdownRenderer = ({
   children,
   defaultText,
+  disabled,
   focusedOption,
   handleRef,
   onLabelClicked,
@@ -26,7 +27,10 @@ const DropdownRenderer = ({
   title,
   width
 }) => {
-  const wrapperClasses = classnames('kedro', 'kui-dropdown', `kui-theme--${theme}`, { 'kui-dropdown--open': open });
+  const wrapperClasses = classnames(
+    'kedro', 'kui-dropdown', `kui-theme--${theme}`,
+    { 'kui-dropdown--open': open, 'kui-dropdown--disabled': disabled }
+  );
   let optionIndex = 0;
 
   /**
@@ -114,6 +118,7 @@ const DropdownRenderer = ({
       title={title}>
       <button
         type='button'
+        disabled={disabled}
         className='kui-dropdown__label'
         onClick={onLabelClicked}>
         <span>{selectedOption.label || defaultText}</span>
@@ -129,6 +134,7 @@ const DropdownRenderer = ({
 DropdownRenderer.defaultProps = {
   children: null,
   defaultText: 'Please select...',
+  disabled: false,
   focusedOption: null,
   handleRef: null,
   onLabelClicked: null,
@@ -150,6 +156,10 @@ DropdownRenderer.propTypes = {
   * Default text to show in a closed unselected state
   */
   defaultText: PropTypes.string,
+  /**
+  * Whether to disable the dropdown
+  */
+  disabled: PropTypes.bool,
   /**
   * The index of the currently-focused menu option
   */

--- a/src/components/dropdown/dropdown.css
+++ b/src/components/dropdown/dropdown.css
@@ -106,7 +106,7 @@ $menu-item-padding: 12px;
 
   position: absolute;
 
-  display: none;
+  visibility: hidden;
   width: 100%;
   max-height: $menu-max-height;
   overflow: auto;
@@ -114,10 +114,15 @@ $menu-item-padding: 12px;
 
   border-style: solid;
   border-width: 1px 0 0;
-  animation: dropdownEntrance 0.3s;
+  transition: opacity ease 0.2s, transform ease 0.2s, visibility ease 0.2s;
+  transform: translateY(-10px);
+  opacity: 0;
 
   .kui-dropdown--open & {
-    display: block;
+    visibility: visible;
+    transition: opacity ease 0.3s, transform ease 0.3s, visibility ease 0.3s;
+    opacity: 1;
+    transform: translateY(0);
   }
 
   > section {
@@ -160,17 +165,5 @@ $menu-item-padding: 12px;
       @extend %type--body-1;
       @extend %type--semibold;
     }
-  }
-}
-
-@keyframes dropdownEntrance {
-  0% {
-    opacity: 0.5;
-    transform: translateY(-10px);
-  }
-
-  100% {
-    opacity: 1;
-    transform: translateY(0);
   }
 }

--- a/src/components/dropdown/dropdown.css
+++ b/src/components/dropdown/dropdown.css
@@ -27,7 +27,7 @@ $menu-item-padding: 12px;
   @mixin themed border-color, menu, wrapper;
 
   &:hover {
-    &:not(.kui-dropdown--open) {
+    &:not(.kui-dropdown--open):not(.kui-dropdown--disabled) {
       @extend %shadow-light--hover;
     }
   }
@@ -45,6 +45,10 @@ $menu-item-padding: 12px;
   position: relative;
 
   z-index: 9;
+}
+
+.kui-dropdown--disabled {
+  opacity: 0.5;
 }
 
 .kui-dropdown__label {
@@ -72,6 +76,10 @@ $menu-item-padding: 12px;
 
   cursor: pointer;
   user-select: none;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
 
   &:focus {
     @mixin themedParent outline-color, focus, secondary;

--- a/src/components/dropdown/dropdown.jsx
+++ b/src/components/dropdown/dropdown.jsx
@@ -319,13 +319,14 @@ class Dropdown extends React.Component {
    */
   render() {
     const {
-      children, defaultText, theme, width
+      children, defaultText, disabled, theme, width
     } = this.props;
     const { open, focusedOption, selectedOption } = this.state;
 
     return (
       <DropdownRenderer
         defaultText={defaultText}
+        disabled={disabled}
         handleRef={this._handleRef}
         onLabelClicked={this._handleLabelClicked}
         onOptionSelected={this._handleOptionSelected}
@@ -344,6 +345,7 @@ class Dropdown extends React.Component {
 Dropdown.defaultProps = {
   children: null,
   defaultText: 'Please select...',
+  disabled: false,
   onChanged: null,
   onClosed: null,
   onOpened: null,
@@ -360,6 +362,10 @@ Dropdown.propTypes = {
   * Default text to show in a closed unselected state
   */
   defaultText: PropTypes.string,
+  /**
+  * Whether to disable the dropdown
+  */
+  disabled: PropTypes.bool,
   /**
    * Callback function to be executed when a menu item is clicked, other than the one currently selected.
    */


### PR DESCRIPTION
## Motivation and Context

We needed to be able to properly disable a dropdown over on Kedro-UI. Ideally every component should this property, but for now I'm just adding it to the dropdown.

Setting the `disabled` prop adds a disabled attribute to the label button, which prevents keyboard usage and indicates the state to screen readers etc. I've also faded it out to 50% as a visual indicator, removed the hover, and added a 'not-allowed' cursor.
![image](https://user-images.githubusercontent.com/1155816/100650004-2e6e4e00-333b-11eb-89cb-2b59f211d3a4.png)


## How has this been tested?

I tested it with mouse, keyboard, and VoiceOver on Chrome.

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking “Submit Pull Request”:

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.

## Checklist

- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added tests to cover my changes
- [x] Assigned myself to the PR
- [x] Added `Type` label to the PR
